### PR TITLE
Fixed invalid file path issue on Windows

### DIFF
--- a/extension/notebookProvider.ts
+++ b/extension/notebookProvider.ts
@@ -143,23 +143,26 @@ export class FormulaNotebookKernel {
 					filePath = cmd.replace("l ", "");
 				}
 
-				if(process.platform === "win32")
-				{
-					filePath = "file:///" + filePath;
-				}
-
-				var folder = path.dirname(cell.notebook.uri.path);
+				var folder = path.dirname(cell.notebook.uri.fsPath);
 
 				cmd = cmd + " " + folder;
 
 				var uri : vscode.Uri | undefined = undefined;
 				if(path.isAbsolute(filePath))
 				{
+					if(process.platform === "win32")
+					{
+						filePath = "file:///" + filePath;
+					}
 					uri = vscode.Uri.parse(filePath);
 				}
 				else
 				{
 					filePath = path.join(folder, filePath);
+					if(process.platform === "win32")
+					{
+						filePath = "file:///" + filePath;
+					}
 					uri = vscode.Uri.parse(filePath);
 				}
 


### PR DESCRIPTION
When using either absolute file path or relative file path to load file on my Windows machine, it will always report "Invalid file path." The different behavior of path.parse() and path.isAbsolute() on Windows file system is causing this issue. Need to check if this error can be repeated on other Windows machine. 